### PR TITLE
Add latency-compensated vision+encoder (E)KF wrappers

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/LinearQuadraticRegulator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/LinearQuadraticRegulator.java
@@ -2,7 +2,11 @@ package edu.wpi.first.wpilibj.controller;
 
 import edu.wpi.first.wpilibj.math.StateSpaceUtils;
 import edu.wpi.first.wpilibj.system.LinearSystem;
-import edu.wpi.first.wpiutil.math.*;
+import edu.wpi.first.wpiutil.math.Drake;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.Num;
+import edu.wpi.first.wpiutil.math.SimpleMatrixUtils;
 import edu.wpi.first.wpiutil.math.numbers.N1;
 import org.ejml.dense.row.CommonOps_DDRM;
 import org.ejml.simple.SimpleMatrix;
@@ -96,8 +100,8 @@ public class LinearQuadraticRegulator<S extends Num, I extends Num,
     this.m_A = A;
     this.m_B = B;
 
-    @SuppressWarnings("LocalVariableName")
     var size = states.getNum() + inputs.getNum();
+    @SuppressWarnings("LocalVariableName")
     var Mcont = new SimpleMatrix(0, 0);
     var scaledA = m_A.times(dtSeconds);
     var scaledB = m_B.times(dtSeconds);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/DifferentialDrivePoseEstimator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/DifferentialDrivePoseEstimator.java
@@ -1,0 +1,129 @@
+package edu.wpi.first.wpilibj.estimator;
+
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.geometry.Twist2d;
+import edu.wpi.first.wpiutil.math.MatBuilder;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+import edu.wpi.first.wpiutil.math.numbers.N3;
+
+/**
+ * This class wraps an Extended Kalman Filter to fuse latency-compensated vision
+ * measurements with differential drive encoder measurements. It will correct
+ * for noisy vision measurements and encoder drift. It is intended to be an easy
+ * drop-in for
+ * {@link edu.wpi.first.wpilibj.kinematics.DifferentialDriveOdometry}; in fact,
+ * if you never call {@link DifferentialDrivePoseEstimator#addVisionMeasurement}
+ * and only call {@link DifferentialDrivePoseEstimator#update} then this will
+ * behave exactly the same as DifferentialDriveOdometry.
+ * <p>
+ * {@link DifferentialDrivePoseEstimator#update} should be called every robot
+ * loop (if your robot loops are faster than the default then you should change
+ * the
+ * {@link DifferentialDrivePoseEstimator#DifferentialDrivePoseEstimator(Rotation2d,
+ * Pose2d, Matrix, Matrix, double) nominal delta time}.)
+ * {@link DifferentialDrivePoseEstimator#addVisionMeasurement} can be called as
+ * infrequently as you want; if you never call it then this class will behave
+ * exactly like regular encoder odometry.
+ * <p>
+ * Our state-space system is:
+ * <p>
+ * x = [[x, y, dtheta]]^T in the field coordinate system.
+ * <p>
+ * u = [[d_l, d_r, dtheta]]^T -- these aren't technically system inputs, but
+ * they make things considerably easier.
+ * <p>
+ * y = [[x, y, theta]]^T
+ */
+public class DifferentialDrivePoseEstimator {
+    private final ExtendedKalmanFilter<N3, N3, N3> m_observer;
+    private final KalmanFilterLatencyCompensator<N3, N3, N3> m_latencyCompensator;
+    /** Seconds */
+    private final double m_nominalDt;
+
+    private Rotation2d m_gyroOffset;
+    private Rotation2d m_previousAngle;
+
+    public DifferentialDrivePoseEstimator(Rotation2d gyroAngle, Pose2d initialPoseMeters, Matrix<N3, N1> stateStdDevs,
+            Matrix<N3, N1> measurementStdDevs) {
+        this(gyroAngle, initialPoseMeters, stateStdDevs, measurementStdDevs, 0.01);
+    }
+
+    public DifferentialDrivePoseEstimator(Rotation2d gyroAngle, Pose2d initialPoseMeters, Matrix<N3, N1> stateStdDevs,
+            Matrix<N3, N1> measurementStdDevs, double nominalDtSeconds) {
+        m_nominalDt = nominalDtSeconds;
+
+        m_observer = new ExtendedKalmanFilter<N3, N3, N3>(Nat.N3(), Nat.N3(), Nat.N3(), this::f, (x, u) -> x,
+                stateStdDevs, measurementStdDevs, false, m_nominalDt);
+        m_latencyCompensator = new KalmanFilterLatencyCompensator<>();
+
+        m_gyroOffset = initialPoseMeters.getRotation().minus(gyroAngle);
+        m_previousAngle = initialPoseMeters.getRotation();
+        m_observer.setXhat(poseToVector(initialPoseMeters));
+    }
+
+    private final Matrix<N3, N1> f(Matrix<N3, N1> x, Matrix<N3, N1> u) {
+        // Diff drive forward kinematics:
+        // v_c = (v_l + v_r) / 2
+        double dx = (u.get(0, 0) + u.get(1, 0)) / 2;
+        var newPose = new Pose2d(x.get(0, 0), x.get(1, 0), new Rotation2d(x.get(2, 0)))
+                .exp(new Twist2d(dx, 0.0, u.get(2, 0)));
+
+        return new MatBuilder<>(Nat.N3(), Nat.N1()).fill(newPose.getTranslation().getX(),
+                newPose.getTranslation().getY(), x.get(2, 0) + u.get(2, 0));
+    }
+
+    /**
+     * Add a vision measurement to the Extended Kalman Filter. This will correct the
+     * odometry pose estimate while still accounting for measurement noise.
+     * <p>
+     * This method can be called as infrequently as you want, as long as you are
+     * calling {@link DifferentialDrivePoseEstimator#update} every loop.
+     * 
+     * @param visionRobotPose  The pose of the robot as measured by the vision
+     *                         camera.
+     * @param timestampSeconds The timestamp of the vision measurement in seconds
+     *                         since FPGA startup (i.e. the epoch of this timestamp
+     *                         is the same epoch as
+     *                         {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp
+     *                         Timer.getFPGATimestamp}.) This means that you should
+     *                         use Timer.getFPGATimestamp as your time source in
+     *                         this case.
+     */
+    public void addVisionMeasurement(Pose2d visionRobotPose, double timestampSeconds) {
+        m_latencyCompensator.applyPastMeasurement(m_observer, m_nominalDt, poseToVector(visionRobotPose),
+                timestampSeconds);
+    }
+
+    /**
+     * Update the the Extended Kalman Filter using only wheel encoder information.
+     * Note that this should be called every loop (and the correct loop period must
+     * be passed into the constructor of this class.)
+     * 
+     * @param gyroAngle           The current gyro angle.
+     * @param leftDistanceMeters  The distance the left wheel has travelled since
+     *                            the last loop iteration.
+     * @param rightDistanceMeters The distance the left wheel has travelled since
+     *                            the last loop iteration.
+     * @return The estimated pose of the robot.
+     */
+    public Pose2d update(Rotation2d gyroAngle, double leftDistanceMeters, double rightDistanceMeters) {
+        var angle = gyroAngle.plus(m_gyroOffset);
+        var u = new MatBuilder<>(Nat.N3(), Nat.N1()).fill(leftDistanceMeters, rightDistanceMeters,
+                angle.minus(m_previousAngle).getRadians());
+        m_previousAngle = angle;
+
+        m_latencyCompensator.addObserverState(m_observer, u);
+        m_observer.predict(u, m_nominalDt);
+
+        return new Pose2d(m_observer.getXhat(0), m_observer.getXhat(1), new Rotation2d(m_observer.getXhat(2)));
+    }
+
+    // TODO: Deduplicate
+    private Matrix<N3, N1> poseToVector(Pose2d pose) {
+        return new MatBuilder<>(Nat.N3(), Nat.N1()).fill(pose.getTranslation().getX(), pose.getTranslation().getY(),
+                pose.getRotation().getRadians());
+    }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/DifferentialDrivePoseEstimator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/DifferentialDrivePoseEstimator.java
@@ -18,8 +18,8 @@ import edu.wpi.first.wpiutil.math.numbers.N3;
  * if you never call {@link DifferentialDrivePoseEstimator#addVisionMeasurement}
  * and only call {@link DifferentialDrivePoseEstimator#update} then this will
  * behave exactly the same as DifferentialDriveOdometry.
- * <p>
- * {@link DifferentialDrivePoseEstimator#update} should be called every robot
+ *
+ * <p>{@link DifferentialDrivePoseEstimator#update} should be called every robot
  * loop (if your robot loops are faster than the default then you should change
  * the
  * {@link DifferentialDrivePoseEstimator#DifferentialDrivePoseEstimator(Rotation2d,
@@ -27,103 +27,137 @@ import edu.wpi.first.wpiutil.math.numbers.N3;
  * {@link DifferentialDrivePoseEstimator#addVisionMeasurement} can be called as
  * infrequently as you want; if you never call it then this class will behave
  * exactly like regular encoder odometry.
- * <p>
- * Our state-space system is:
- * <p>
- * x = [[x, y, dtheta]]^T in the field coordinate system.
- * <p>
- * u = [[d_l, d_r, dtheta]]^T -- these aren't technically system inputs, but
+ *
+ * <p>Our state-space system is:
+ *
+ * <p>x = [[x, y, dtheta]]^T in the field coordinate system.
+ *
+ * <p>u = [[d_l, d_r, dtheta]]^T -- these aren't technically system inputs, but
  * they make things considerably easier.
- * <p>
- * y = [[x, y, theta]]^T
+ *
+ * <p>y = [[x, y, theta]]^T
  */
 public class DifferentialDrivePoseEstimator {
-    private final ExtendedKalmanFilter<N3, N3, N3> m_observer;
-    private final KalmanFilterLatencyCompensator<N3, N3, N3> m_latencyCompensator;
-    /** Seconds */
-    private final double m_nominalDt;
+  private final ExtendedKalmanFilter<N3, N3, N3> m_observer;
+  private final KalmanFilterLatencyCompensator<N3, N3, N3> m_latencyCompensator;
 
-    private Rotation2d m_gyroOffset;
-    private Rotation2d m_previousAngle;
+  private final double m_nominalDt; // Seconds
 
-    public DifferentialDrivePoseEstimator(Rotation2d gyroAngle, Pose2d initialPoseMeters, Matrix<N3, N1> stateStdDevs,
-            Matrix<N3, N1> measurementStdDevs) {
-        this(gyroAngle, initialPoseMeters, stateStdDevs, measurementStdDevs, 0.01);
-    }
+  private Rotation2d m_gyroOffset;
+  private Rotation2d m_previousAngle;
 
-    public DifferentialDrivePoseEstimator(Rotation2d gyroAngle, Pose2d initialPoseMeters, Matrix<N3, N1> stateStdDevs,
-            Matrix<N3, N1> measurementStdDevs, double nominalDtSeconds) {
-        m_nominalDt = nominalDtSeconds;
+  public DifferentialDrivePoseEstimator(
+          Rotation2d gyroAngle, Pose2d initialPoseMeters,
+          Matrix<N3, N1> stateStdDevs, Matrix<N3, N1> measurementStdDevs
+  ) {
+    this(gyroAngle, initialPoseMeters, stateStdDevs, measurementStdDevs, 0.01);
+  }
 
-        m_observer = new ExtendedKalmanFilter<N3, N3, N3>(Nat.N3(), Nat.N3(), Nat.N3(), this::f, (x, u) -> x,
-                stateStdDevs, measurementStdDevs, false, m_nominalDt);
-        m_latencyCompensator = new KalmanFilterLatencyCompensator<>();
+  /**
+   * Constructs a DifferentialDrivePose estimator.
+   *
+   * @param gyroAngle          The current gyro angle.
+   * @param initialPoseMeters  The starting pose estimate.
+   * @param stateStdDevs       Standard deviations of model states. Increase these numbers to trust
+   *                           your encoders less.
+   * @param measurementStdDevs Standard deviations of the measurements. Increase these numbers to
+   *                           trust vision less.
+   * @param nominalDtSeconds   The time in seconds between each robot loop.
+   */
+  @SuppressWarnings("ParameterName")
+  public DifferentialDrivePoseEstimator(
+          Rotation2d gyroAngle, Pose2d initialPoseMeters,
+          Matrix<N3, N1> stateStdDevs, Matrix<N3, N1> measurementStdDevs,
+          double nominalDtSeconds
+  ) {
+    m_nominalDt = nominalDtSeconds;
 
-        m_gyroOffset = initialPoseMeters.getRotation().minus(gyroAngle);
-        m_previousAngle = initialPoseMeters.getRotation();
-        m_observer.setXhat(poseToVector(initialPoseMeters));
-    }
+    m_observer = new ExtendedKalmanFilter<>(
+            Nat.N3(), Nat.N3(), Nat.N3(),
+            this::f, (x, u) -> x,
+            stateStdDevs, measurementStdDevs,
+            false, m_nominalDt);
+    m_latencyCompensator = new KalmanFilterLatencyCompensator<>();
 
-    private final Matrix<N3, N1> f(Matrix<N3, N1> x, Matrix<N3, N1> u) {
-        // Diff drive forward kinematics:
-        // v_c = (v_l + v_r) / 2
-        double dx = (u.get(0, 0) + u.get(1, 0)) / 2;
-        var newPose = new Pose2d(x.get(0, 0), x.get(1, 0), new Rotation2d(x.get(2, 0)))
-                .exp(new Twist2d(dx, 0.0, u.get(2, 0)));
+    m_gyroOffset = initialPoseMeters.getRotation().minus(gyroAngle);
+    m_previousAngle = initialPoseMeters.getRotation();
+    m_observer.setXhat(poseToVector(initialPoseMeters));
+  }
 
-        return new MatBuilder<>(Nat.N3(), Nat.N1()).fill(newPose.getTranslation().getX(),
-                newPose.getTranslation().getY(), x.get(2, 0) + u.get(2, 0));
-    }
+  @SuppressWarnings({"ParameterName", "MethodName"})
+  private Matrix<N3, N1> f(Matrix<N3, N1> x, Matrix<N3, N1> u) {
+    // Diff drive forward kinematics:
+    // v_c = (v_l + v_r) / 2
+    double dx = (u.get(0, 0) + u.get(1, 0)) / 2;
+    var newPose = new Pose2d(x.get(0, 0), x.get(1, 0), new Rotation2d(x.get(2, 0)))
+            .exp(new Twist2d(dx, 0.0, u.get(2, 0)));
 
-    /**
-     * Add a vision measurement to the Extended Kalman Filter. This will correct the
-     * odometry pose estimate while still accounting for measurement noise.
-     * <p>
-     * This method can be called as infrequently as you want, as long as you are
-     * calling {@link DifferentialDrivePoseEstimator#update} every loop.
-     * 
-     * @param visionRobotPose  The pose of the robot as measured by the vision
-     *                         camera.
-     * @param timestampSeconds The timestamp of the vision measurement in seconds
-     *                         since FPGA startup (i.e. the epoch of this timestamp
-     *                         is the same epoch as
-     *                         {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp
-     *                         Timer.getFPGATimestamp}.) This means that you should
-     *                         use Timer.getFPGATimestamp as your time source in
-     *                         this case.
-     */
-    public void addVisionMeasurement(Pose2d visionRobotPose, double timestampSeconds) {
-        m_latencyCompensator.applyPastMeasurement(m_observer, m_nominalDt, poseToVector(visionRobotPose),
-                timestampSeconds);
-    }
+    return new MatBuilder<>(Nat.N3(), Nat.N1()).fill(newPose.getTranslation().getX(),
+            newPose.getTranslation().getY(), x.get(2, 0) + u.get(2, 0));
+  }
 
-    /**
-     * Update the the Extended Kalman Filter using only wheel encoder information.
-     * Note that this should be called every loop (and the correct loop period must
-     * be passed into the constructor of this class.)
-     * 
-     * @param gyroAngle           The current gyro angle.
-     * @param leftDistanceMeters  The distance the left wheel has travelled since
-     *                            the last loop iteration.
-     * @param rightDistanceMeters The distance the left wheel has travelled since
-     *                            the last loop iteration.
-     * @return The estimated pose of the robot.
-     */
-    public Pose2d update(Rotation2d gyroAngle, double leftDistanceMeters, double rightDistanceMeters) {
-        var angle = gyroAngle.plus(m_gyroOffset);
-        var u = new MatBuilder<>(Nat.N3(), Nat.N1()).fill(leftDistanceMeters, rightDistanceMeters,
-                angle.minus(m_previousAngle).getRadians());
-        m_previousAngle = angle;
+  /**
+   * Add a vision measurement to the Extended Kalman Filter. This will correct the
+   * odometry pose estimate while still accounting for measurement noise.
+   *
+   * <p>This method can be called as infrequently as you want, as long as you are
+   * calling {@link DifferentialDrivePoseEstimator#update} every loop.
+   *
+   * @param visionRobotPose  The pose of the robot as measured by the vision
+   *                         camera.
+   * @param timestampSeconds The timestamp of the vision measurement in seconds
+   *                         since FPGA startup (i.e. the epoch of this timestamp
+   *                         is the same epoch as
+   *                         {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp
+   *                         Timer.getFPGATimestamp}.) This means that you should
+   *                         use Timer.getFPGATimestamp as your time source in
+   *                         this case.
+   */
+  public void addVisionMeasurement(Pose2d visionRobotPose, double timestampSeconds) {
+    m_latencyCompensator.applyPastMeasurement(
+            m_observer, m_nominalDt,
+            poseToVector(visionRobotPose), timestampSeconds
+    );
+  }
 
-        m_latencyCompensator.addObserverState(m_observer, u);
-        m_observer.predict(u, m_nominalDt);
+  /**
+   * Updates the the Extended Kalman Filter using only wheel encoder information.
+   * Note that this should be called every loop (and the correct loop period must
+   * be passed into the constructor of this class.)
+   *
+   * @param gyroAngle           The current gyro angle.
+   * @param leftDistanceMeters  The distance the left wheel has travelled since
+   *                            the last loop iteration.
+   * @param rightDistanceMeters The distance the left wheel has travelled since
+   *                            the last loop iteration.
+   * @return The estimated pose of the robot.
+   */
+  @SuppressWarnings("LocalVariableName")
+  public Pose2d update(
+          Rotation2d gyroAngle,
+          double leftDistanceMeters, double rightDistanceMeters
+  ) {
+    var angle = gyroAngle.plus(m_gyroOffset);
+    var u = new MatBuilder<>(Nat.N3(), Nat.N1()).fill(leftDistanceMeters, rightDistanceMeters,
+            angle.minus(m_previousAngle).getRadians());
+    m_previousAngle = angle;
 
-        return new Pose2d(m_observer.getXhat(0), m_observer.getXhat(1), new Rotation2d(m_observer.getXhat(2)));
-    }
+    m_latencyCompensator.addObserverState(m_observer, u);
+    m_observer.predict(u, m_nominalDt);
 
-    // TODO: Deduplicate
-    private Matrix<N3, N1> poseToVector(Pose2d pose) {
-        return new MatBuilder<>(Nat.N3(), Nat.N1()).fill(pose.getTranslation().getX(), pose.getTranslation().getY(),
-                pose.getRotation().getRadians());
-    }
+    return new Pose2d(
+            m_observer.getXhat(0),
+            m_observer.getXhat(1),
+            new Rotation2d(m_observer.getXhat(2))
+    );
+  }
+
+  // TODO: Deduplicate
+  private Matrix<N3, N1> poseToVector(Pose2d pose) {
+    return new MatBuilder<>(Nat.N3(), Nat.N1()).fill(
+            pose.getTranslation().getX(),
+            pose.getTranslation().getY(),
+            pose.getRotation().getRadians()
+    );
+  }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/ExtendedKalmanFilter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/ExtendedKalmanFilter.java
@@ -9,7 +9,7 @@ import edu.wpi.first.wpiutil.math.numbers.N1;
 import java.util.function.BiFunction;
 
 
-public class ExtendedKalmanFilter<S extends Num, I extends Num, O extends Num> {
+public class ExtendedKalmanFilter<S extends Num, I extends Num, O extends Num> implements KalmanTypeFilter<S, I, O> {
 
   private final boolean m_useRungeKutta;
 
@@ -92,6 +92,7 @@ public class ExtendedKalmanFilter<S extends Num, I extends Num, O extends Num> {
    *
    * @return the error covariance matrix P.
    */
+  @Override
   public Matrix<S, S> getP() {
     return m_P;
   }
@@ -101,6 +102,7 @@ public class ExtendedKalmanFilter<S extends Num, I extends Num, O extends Num> {
    *
    * @param newP The new value of P to use.
    */
+  @Override
   public void setP(Matrix<S, S> newP) {
     m_P = newP;
   }
@@ -112,6 +114,7 @@ public class ExtendedKalmanFilter<S extends Num, I extends Num, O extends Num> {
    * @param col Column of P.
    * @return the value of the error covariance matrix P at (i, j).
    */
+  @Override
   public double getP(int row, int col) {
     return m_P.get(row, col);
   }
@@ -121,6 +124,7 @@ public class ExtendedKalmanFilter<S extends Num, I extends Num, O extends Num> {
    *
    * @return the state estimate x-hat.
    */
+  @Override
   public Matrix<S, N1> getXhat() {
     return m_xHat;
   }
@@ -131,6 +135,7 @@ public class ExtendedKalmanFilter<S extends Num, I extends Num, O extends Num> {
    * @param xHat The state estimate x-hat.
    */
   @SuppressWarnings("ParameterName")
+  @Override
   public void setXhat(Matrix<S, N1> xHat) {
     m_xHat = xHat;
   }
@@ -141,6 +146,7 @@ public class ExtendedKalmanFilter<S extends Num, I extends Num, O extends Num> {
    * @param row Row of x-hat.
    * @return the value of the state estimate x-hat at i.
    */
+  @Override
   public double getXhat(int row) {
     return m_xHat.get(row, 0);
   }
@@ -151,10 +157,12 @@ public class ExtendedKalmanFilter<S extends Num, I extends Num, O extends Num> {
    * @param row   Row of x-hat.
    * @param value Value for element of x-hat.
    */
+  @Override
   public void setXhat(int row, double value) {
     m_xHat.set(row, 0, value);
   }
 
+  @Override
   public void reset() {
     m_xHat = MatrixUtils.zeros(m_states);
     m_P = m_initP;
@@ -167,6 +175,7 @@ public class ExtendedKalmanFilter<S extends Num, I extends Num, O extends Num> {
    * @param dtSeconds Timestep for prediction.
    */
   @SuppressWarnings("ParameterName")
+  @Override
   public void predict(Matrix<I, N1> u, double dtSeconds) {
     predict(u, m_f, dtSeconds);
   }
@@ -208,6 +217,7 @@ public class ExtendedKalmanFilter<S extends Num, I extends Num, O extends Num> {
    * @param y Measurement vector.
    */
   @SuppressWarnings("ParameterName")
+  @Override
   public void correct(Matrix<I, N1> u, Matrix<O, N1> y) {
     correct(m_outputs, u, y, m_h, m_discR);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanFilter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanFilter.java
@@ -26,7 +26,7 @@ import org.ejml.simple.SimpleMatrix;
  * https://file.tavsys.net/control/controls-engineering-in-frc.pdf.
  */
 public class KalmanFilter<S extends Num, I extends Num,
-        O extends Num> {
+        O extends Num> implements KalmanTypeFilter<S, I, O> {
 
   /**
    * The states of the system.
@@ -118,8 +118,19 @@ public class KalmanFilter<S extends Num, I extends Num,
    * @param col Column of P.
    * @return the element (i, j) of the error covariance matrix P.
    */
+  @Override
   public double getP(int row, int col) {
     return m_P.get(row, col);
+  }
+
+  /**
+   * Sets the entire error covariance matrix P.
+   *
+   * @param newP The new value of P to use.
+   */
+  @Override
+  public void setP(Matrix<S, S> newP) {
+    m_P = newP;
   }
 
   /**
@@ -127,6 +138,7 @@ public class KalmanFilter<S extends Num, I extends Num,
    *
    * @param xhat The state estimate x-hat.
    */
+  @Override
   public void setXhat(Matrix<S, N1> xhat) {
     m_plant.setX(xhat);
   }
@@ -146,6 +158,7 @@ public class KalmanFilter<S extends Num, I extends Num,
    *
    * @return The state estimate x-hat.
    */
+  @Override
   public Matrix<S, N1> getXhat() {
     return m_plant.getX();
   }
@@ -156,6 +169,7 @@ public class KalmanFilter<S extends Num, I extends Num,
    * @param row Row of x-hat.
    * @return the state estimate x-hat at i.
    */
+  @Override
   public double getXhat(int row) {
     return m_plant.getX(row);
   }
@@ -163,6 +177,7 @@ public class KalmanFilter<S extends Num, I extends Num,
   /**
    * Resets the observer.
    */
+  @Override
   public void reset() {
     m_plant.reset();
   }
@@ -174,6 +189,7 @@ public class KalmanFilter<S extends Num, I extends Num,
    * @param dtSeconds Timestep for prediction.
    */
   @SuppressWarnings("ParameterName")
+  @Override
   public void predict(Matrix<I, N1> u, double dtSeconds) {
     m_plant.setX(m_plant.calculateX(m_plant.getX(), u, dtSeconds));
 
@@ -192,6 +208,7 @@ public class KalmanFilter<S extends Num, I extends Num,
    * @param y Measurement vector.
    */
   @SuppressWarnings("ParameterName")
+  @Override
   public void correct(Matrix<I, N1> u, Matrix<O, N1> y) {
     correct(u, y, m_plant.getC(), m_discR);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanFilter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanFilter.java
@@ -1,11 +1,16 @@
 package edu.wpi.first.wpilibj.estimator;
 
+import org.ejml.simple.SimpleMatrix;
 
 import edu.wpi.first.wpilibj.math.StateSpaceUtils;
 import edu.wpi.first.wpilibj.system.LinearSystem;
-import edu.wpi.first.wpiutil.math.*;
+import edu.wpi.first.wpiutil.math.Drake;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.MatrixUtils;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.Num;
+import edu.wpi.first.wpiutil.math.SimpleMatrixUtils;
 import edu.wpi.first.wpiutil.math.numbers.N1;
-import org.ejml.simple.SimpleMatrix;
 
 /**
  * Luenberger observers combine predictions from a model and measurements to

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanFilterLatencyCompensator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanFilterLatencyCompensator.java
@@ -1,0 +1,84 @@
+package edu.wpi.first.wpilibj.estimator;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.Num;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+
+class KalmanFilterLatencyCompensator<S extends Num, I extends Num, O extends Num>
+{
+    private final static int k_maxPastObserverStates = 300;
+
+    private final TreeMap<Double, ObserverState> m_pastObserverStates;
+
+    public KalmanFilterLatencyCompensator()
+    {
+        m_pastObserverStates = new TreeMap<>();
+    }
+
+    public void addObserverState(KalmanTypeFilter<S, I, O> observer, Matrix<I, N1> u)
+    {
+        m_pastObserverStates.put(Timer.getFPGATimestamp(), new ObserverState(observer, u));
+        
+        if (m_pastObserverStates.size() > k_maxPastObserverStates) {
+            m_pastObserverStates.remove(m_pastObserverStates.firstKey());
+        }
+    }
+
+    public void applyPastMeasurement(
+        KalmanTypeFilter<S, I, O> observer,
+        double dtSeconds,
+        Matrix<O, N1> y,
+        double timestampSeconds
+    ) {
+        var low = m_pastObserverStates.floorEntry(timestampSeconds);
+        var high = m_pastObserverStates.ceilingEntry(timestampSeconds);
+
+        // Find the entry closest in time to timestampSeconds
+        Map.Entry<Double, ObserverState> closestEntry = null;
+        if (low != null && high != null) {
+            closestEntry = Math.abs(timestampSeconds - low.getKey()) < Math.abs(timestampSeconds - high.getKey()) ? low
+                    : high;
+        } else {
+            closestEntry = low != null ? low : high;
+        }
+        if (closestEntry == null) {
+            // State map was empty, which means that we got a past measurement right at startup
+            // The only thing we can really do is ignore the measurement
+            return;
+        }
+
+        var tailMap = m_pastObserverStates.tailMap(closestEntry.getKey(), true);
+        for (var st : tailMap.values()) {
+            if (y != null) {
+                observer.setP(st.errorCovariances);
+                observer.setXhat(st.xHat);
+                // Note that we correct the observer with inputs closest in time to the measurement
+                // This makes the assumption that the dt is small enough that the difference between the measurement time and the time that the inputs were captured at is very small
+                observer.correct(st.inputs, y);
+            }
+            observer.predict(st.inputs, dtSeconds);
+
+            y = null;
+        }
+    }
+
+    /**
+     * This class contains all the information about our observer 
+     */
+    public class ObserverState {
+        public final Matrix<S, N1> xHat;
+        public final Matrix<S, S> errorCovariances;
+        public final Matrix<I, N1> inputs;
+
+        private ObserverState(KalmanTypeFilter<S, I, O> observer, Matrix<I, N1> u) {
+            this.xHat = observer.getXhat();
+            this.errorCovariances = observer.getP();
+
+            inputs = u;
+        }
+    }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanFilterLatencyCompensator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanFilterLatencyCompensator.java
@@ -8,77 +8,80 @@ import edu.wpi.first.wpiutil.math.Matrix;
 import edu.wpi.first.wpiutil.math.Num;
 import edu.wpi.first.wpiutil.math.numbers.N1;
 
-class KalmanFilterLatencyCompensator<S extends Num, I extends Num, O extends Num>
-{
-    private final static int k_maxPastObserverStates = 300;
+class KalmanFilterLatencyCompensator<S extends Num, I extends Num, O extends Num> {
+  private static final int k_maxPastObserverStates = 300;
 
-    private final TreeMap<Double, ObserverState> m_pastObserverStates;
+  private final TreeMap<Double, ObserverState> m_pastObserverStates;
 
-    public KalmanFilterLatencyCompensator()
-    {
-        m_pastObserverStates = new TreeMap<>();
+  KalmanFilterLatencyCompensator() {
+    m_pastObserverStates = new TreeMap<>();
+  }
+
+  @SuppressWarnings("ParameterName")
+  public void addObserverState(KalmanTypeFilter<S, I, O> observer, Matrix<I, N1> u) {
+    m_pastObserverStates.put(Timer.getFPGATimestamp(), new ObserverState(observer, u));
+
+    if (m_pastObserverStates.size() > k_maxPastObserverStates) {
+      m_pastObserverStates.remove(m_pastObserverStates.firstKey());
+    }
+  }
+
+  @SuppressWarnings("ParameterName")
+  public void applyPastMeasurement(
+          KalmanTypeFilter<S, I, O> observer,
+          double dtSeconds,
+          Matrix<O, N1> y,
+          double timestampSeconds
+  ) {
+    var low = m_pastObserverStates.floorEntry(timestampSeconds);
+    var high = m_pastObserverStates.ceilingEntry(timestampSeconds);
+
+    // Find the entry closest in time to timestampSeconds
+    Map.Entry<Double, ObserverState> closestEntry = null;
+    if (low != null && high != null) {
+      closestEntry =
+              Math.abs(timestampSeconds - low.getKey()) < Math.abs(timestampSeconds - high.getKey())
+                      ? low : high;
+    } else {
+      closestEntry = low != null ? low : high;
+    }
+    if (closestEntry == null) {
+      // State map was empty, which means that we got a past measurement right at startup
+      // The only thing we can really do is ignore the measurement
+      return;
     }
 
-    public void addObserverState(KalmanTypeFilter<S, I, O> observer, Matrix<I, N1> u)
-    {
-        m_pastObserverStates.put(Timer.getFPGATimestamp(), new ObserverState(observer, u));
-        
-        if (m_pastObserverStates.size() > k_maxPastObserverStates) {
-            m_pastObserverStates.remove(m_pastObserverStates.firstKey());
-        }
+    var tailMap = m_pastObserverStates.tailMap(closestEntry.getKey(), true);
+    for (var st : tailMap.values()) {
+      if (y != null) {
+        observer.setP(st.errorCovariances);
+        observer.setXhat(st.xHat);
+        // Note that we correct the observer with inputs closest in time to the measurement
+        // This makes the assumption that the dt is small enough that the difference between the
+        // measurement time and the time that the inputs were captured at is very small
+        observer.correct(st.inputs, y);
+      }
+      observer.predict(st.inputs, dtSeconds);
+
+      y = null;
     }
+  }
 
-    public void applyPastMeasurement(
-        KalmanTypeFilter<S, I, O> observer,
-        double dtSeconds,
-        Matrix<O, N1> y,
-        double timestampSeconds
-    ) {
-        var low = m_pastObserverStates.floorEntry(timestampSeconds);
-        var high = m_pastObserverStates.ceilingEntry(timestampSeconds);
+  /**
+   * This class contains all the information about our observer at a given time.
+   */
+  @SuppressWarnings("MemberName")
+  public class ObserverState {
+    public final Matrix<S, N1> xHat;
+    public final Matrix<S, S> errorCovariances;
+    public final Matrix<I, N1> inputs;
 
-        // Find the entry closest in time to timestampSeconds
-        Map.Entry<Double, ObserverState> closestEntry = null;
-        if (low != null && high != null) {
-            closestEntry = Math.abs(timestampSeconds - low.getKey()) < Math.abs(timestampSeconds - high.getKey()) ? low
-                    : high;
-        } else {
-            closestEntry = low != null ? low : high;
-        }
-        if (closestEntry == null) {
-            // State map was empty, which means that we got a past measurement right at startup
-            // The only thing we can really do is ignore the measurement
-            return;
-        }
+    @SuppressWarnings("ParameterName")
+    private ObserverState(KalmanTypeFilter<S, I, O> observer, Matrix<I, N1> u) {
+      this.xHat = observer.getXhat();
+      this.errorCovariances = observer.getP();
 
-        var tailMap = m_pastObserverStates.tailMap(closestEntry.getKey(), true);
-        for (var st : tailMap.values()) {
-            if (y != null) {
-                observer.setP(st.errorCovariances);
-                observer.setXhat(st.xHat);
-                // Note that we correct the observer with inputs closest in time to the measurement
-                // This makes the assumption that the dt is small enough that the difference between the measurement time and the time that the inputs were captured at is very small
-                observer.correct(st.inputs, y);
-            }
-            observer.predict(st.inputs, dtSeconds);
-
-            y = null;
-        }
+      inputs = u;
     }
-
-    /**
-     * This class contains all the information about our observer 
-     */
-    public class ObserverState {
-        public final Matrix<S, N1> xHat;
-        public final Matrix<S, S> errorCovariances;
-        public final Matrix<I, N1> inputs;
-
-        private ObserverState(KalmanTypeFilter<S, I, O> observer, Matrix<I, N1> u) {
-            this.xHat = observer.getXhat();
-            this.errorCovariances = observer.getP();
-
-            inputs = u;
-        }
-    }
+  }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanFilterLatencyCompensator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanFilterLatencyCompensator.java
@@ -18,8 +18,10 @@ class KalmanFilterLatencyCompensator<S extends Num, I extends Num, O extends Num
   }
 
   @SuppressWarnings("ParameterName")
-  public void addObserverState(KalmanTypeFilter<S, I, O> observer, Matrix<I, N1> u) {
-    m_pastObserverStates.put(Timer.getFPGATimestamp(), new ObserverState(observer, u));
+  public void addObserverState(
+          KalmanTypeFilter<S, I, O> observer, Matrix<I, N1> u, double timestampSeconds
+  ) {
+    m_pastObserverStates.put(timestampSeconds, new ObserverState(observer, u));
 
     if (m_pastObserverStates.size() > k_maxPastObserverStates) {
       m_pastObserverStates.remove(m_pastObserverStates.firstKey());
@@ -29,7 +31,7 @@ class KalmanFilterLatencyCompensator<S extends Num, I extends Num, O extends Num
   @SuppressWarnings("ParameterName")
   public void applyPastMeasurement(
           KalmanTypeFilter<S, I, O> observer,
-          double dtSeconds,
+          double nominalDtSeconds,
           Matrix<O, N1> y,
           double timestampSeconds
   ) {
@@ -61,7 +63,7 @@ class KalmanFilterLatencyCompensator<S extends Num, I extends Num, O extends Num
         // measurement time and the time that the inputs were captured at is very small
         observer.correct(st.inputs, y);
       }
-      observer.predict(st.inputs, dtSeconds);
+      observer.predict(st.inputs, nominalDtSeconds); // TODO: remove use of nominal dt
 
       y = null;
     }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanTypeFilter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanTypeFilter.java
@@ -1,0 +1,28 @@
+package edu.wpi.first.wpilibj.estimator;
+
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.Num;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+
+interface KalmanTypeFilter<S extends Num, I extends Num, O extends Num>
+{
+    Matrix<S, S> getP();
+
+    double getP(int i, int j);
+
+    void setP(Matrix<S, S> newP);
+
+    Matrix<S, N1> getXhat();
+
+    double getXhat(int i);
+
+    void setXhat(Matrix<S, N1> xHat);
+    
+    void setXhat(int i, double value);
+
+    void reset();
+    
+    void predict(Matrix<I, N1> u, double dtSeconds);
+
+    void correct(Matrix<I, N1> u, Matrix<O, N1> y);
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanTypeFilter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanTypeFilter.java
@@ -4,25 +4,25 @@ import edu.wpi.first.wpiutil.math.Matrix;
 import edu.wpi.first.wpiutil.math.Num;
 import edu.wpi.first.wpiutil.math.numbers.N1;
 
-interface KalmanTypeFilter<S extends Num, I extends Num, O extends Num>
-{
-    Matrix<S, S> getP();
+@SuppressWarnings("ParameterName")
+interface KalmanTypeFilter<S extends Num, I extends Num, O extends Num> {
+  Matrix<S, S> getP();
 
-    double getP(int i, int j);
+  double getP(int i, int j);
 
-    void setP(Matrix<S, S> newP);
+  void setP(Matrix<S, S> newP);
 
-    Matrix<S, N1> getXhat();
+  Matrix<S, N1> getXhat();
 
-    double getXhat(int i);
+  double getXhat(int i);
 
-    void setXhat(Matrix<S, N1> xHat);
-    
-    void setXhat(int i, double value);
+  void setXhat(Matrix<S, N1> xHat);
 
-    void reset();
-    
-    void predict(Matrix<I, N1> u, double dtSeconds);
+  void setXhat(int i, double value);
 
-    void correct(Matrix<I, N1> u, Matrix<O, N1> y);
+  void reset();
+
+  void predict(Matrix<I, N1> u, double dtSeconds);
+
+  void correct(Matrix<I, N1> u, Matrix<O, N1> y);
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/MerweScaledSigmaPoints.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/MerweScaledSigmaPoints.java
@@ -1,10 +1,11 @@
 package edu.wpi.first.wpilibj.estimator;
 
+import org.ejml.simple.SimpleMatrix;
+
 import edu.wpi.first.wpiutil.math.Matrix;
 import edu.wpi.first.wpiutil.math.Num;
 import edu.wpi.first.wpiutil.math.SimpleMatrixUtils;
 import edu.wpi.first.wpiutil.math.numbers.N1;
-import org.ejml.simple.SimpleMatrix;
 
 /**
  * Generates sigma points and weights according to Van der Merwe's 2004
@@ -66,9 +67,10 @@ public class MerweScaledSigmaPoints<S extends Num> {
    * @param x An array of the means.
    * @param P Covariance of the filter.
    * @return Two dimensional array of sigma points. Each column contains all of
-   * the sigmas for one dimension in the problem space. Ordered by
-   * Xi_0, Xi_{1..n}, Xi_{n+1..2n}.
+   *         the sigmas for one dimension in the problem space. Ordered by
+   *         Xi_0, Xi_{1..n}, Xi_{n+1..2n}.
    */
+  @SuppressWarnings({"ParameterName", "LocalVariableName"})
   public Matrix sigmaPoints(
           Matrix<S, N1> x,
           Matrix<S, S> P) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/SwerveDrivePoseEstimator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/SwerveDrivePoseEstimator.java
@@ -1,0 +1,80 @@
+package edu.wpi.first.wpilibj.estimator;
+
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.kinematics.SwerveDriveKinematics;
+import edu.wpi.first.wpilibj.kinematics.SwerveModuleState;
+import edu.wpi.first.wpilibj.system.LinearSystem;
+import edu.wpi.first.wpiutil.math.MatBuilder;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.MatrixUtils;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+import edu.wpi.first.wpiutil.math.numbers.N3;
+
+public class SwerveDrivePoseEstimator {
+    private final KalmanFilter<N3, N3, N3> m_observer;
+    private final LinearSystem<N3, N3, N3> m_observerSystem;
+    private final KalmanFilterLatencyCompensator<N3, N3, N3> m_latencyCompensator;
+    /** Seconds **/
+    private final double m_nominalDt;
+
+    private Rotation2d m_gyroOffset;
+    private Rotation2d m_previousAngle;
+
+    public SwerveDrivePoseEstimator(Rotation2d gyroAngle, Pose2d initialPoseMeters, SwerveDriveKinematics kinematics,
+        Matrix<N3, N1> stateStdDevs, Matrix<N3, N1> measurementStdDevs) {
+        this(gyroAngle, initialPoseMeters, kinematics, stateStdDevs, measurementStdDevs, 0.01);
+    }
+
+    public SwerveDrivePoseEstimator(Rotation2d gyroAngle, Pose2d initialPoseMeters, SwerveDriveKinematics kinematics,
+            Matrix<N3, N1> stateStdDevs, Matrix<N3, N1> measurementStdDevs, double nominalDtSeconds) {
+        m_nominalDt = nominalDtSeconds;
+
+        m_observerSystem = new LinearSystem<>(
+            Nat.N3(), Nat.N3(), Nat.N3(),
+            new MatBuilder<>(Nat.N3(), Nat.N3()).fill(
+
+            ),
+            new MatBuilder<>(Nat.N3(), Nat.N3()).fill(
+
+            ),
+            new MatBuilder<>(Nat.N3(), Nat.N3()).fill(
+
+            ),
+            MatrixUtils.zeros(Nat.N3(), Nat.N3()),
+            new MatBuilder<>(Nat.N3(), Nat.N1()).fill(),
+            new MatBuilder<>(Nat.N3(), Nat.N1()).fill()
+        );
+        m_observer = new KalmanFilter<>(Nat.N3(), Nat.N3(), Nat.N3(), m_observerSystem, stateStdDevs,
+            measurementStdDevs, nominalDtSeconds);
+        m_latencyCompensator = new KalmanFilterLatencyCompensator<>();
+
+        m_gyroOffset = initialPoseMeters.getRotation().minus(gyroAngle);
+        m_previousAngle = initialPoseMeters.getRotation();
+        m_observer.setXhat(poseToVector(initialPoseMeters));
+    }
+
+    public void addVisionMeasurement(Pose2d visionRobotPose, double timestampSeconds) {
+        m_latencyCompensator.applyPastMeasurement(m_observer, m_nominalDt, poseToVector(visionRobotPose),
+                timestampSeconds);
+    }
+
+    public Pose2d update(Rotation2d gyroAngle, SwerveModuleState... moduleStates) {
+        var angle = gyroAngle.plus(m_gyroOffset);
+        var u = new MatBuilder<>(Nat.N3(), Nat.N1()).fill(leftDistanceMeters, rightDistanceMeters,
+                angle.minus(m_previousAngle).getRadians());
+        m_previousAngle = angle;
+
+        m_latencyCompensator.addObserverState(m_observer, u);
+        m_observer.predict(u, m_nominalDt);
+
+        return new Pose2d(m_observer.getXhat(0), m_observer.getXhat(1), new Rotation2d(m_observer.getXhat(2)));
+    }
+
+    // TODO: Deduplicate
+    private Matrix<N3, N1> poseToVector(Pose2d pose) {
+        return new MatBuilder<>(Nat.N3(), Nat.N1()).fill(pose.getTranslation().getX(), pose.getTranslation().getY(),
+                pose.getRotation().getRadians());
+    }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/SwerveDrivePoseEstimator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/SwerveDrivePoseEstimator.java
@@ -2,6 +2,7 @@ package edu.wpi.first.wpilibj.estimator;
 
 import edu.wpi.first.wpilibj.geometry.Pose2d;
 import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.geometry.Twist2d;
 import edu.wpi.first.wpilibj.kinematics.SwerveDriveKinematics;
 import edu.wpi.first.wpilibj.kinematics.SwerveModuleState;
 import edu.wpi.first.wpilibj.system.LinearSystem;
@@ -13,68 +14,147 @@ import edu.wpi.first.wpiutil.math.numbers.N1;
 import edu.wpi.first.wpiutil.math.numbers.N3;
 
 public class SwerveDrivePoseEstimator {
-    private final KalmanFilter<N3, N3, N3> m_observer;
-    private final LinearSystem<N3, N3, N3> m_observerSystem;
-    private final KalmanFilterLatencyCompensator<N3, N3, N3> m_latencyCompensator;
-    /** Seconds **/
-    private final double m_nominalDt;
+  private final KalmanFilter<N3, N3, N3> m_observer;
+  private final SwerveDriveKinematics m_kinematics;
+  private final KalmanFilterLatencyCompensator<N3, N3, N3> m_latencyCompensator;
 
-    private Rotation2d m_gyroOffset;
-    private Rotation2d m_previousAngle;
+  private final double m_nominalDt; // Seconds
 
-    public SwerveDrivePoseEstimator(Rotation2d gyroAngle, Pose2d initialPoseMeters, SwerveDriveKinematics kinematics,
-        Matrix<N3, N1> stateStdDevs, Matrix<N3, N1> measurementStdDevs) {
-        this(gyroAngle, initialPoseMeters, kinematics, stateStdDevs, measurementStdDevs, 0.01);
-    }
+  private Rotation2d m_gyroOffset;
+  private Rotation2d m_previousAngle;
 
-    public SwerveDrivePoseEstimator(Rotation2d gyroAngle, Pose2d initialPoseMeters, SwerveDriveKinematics kinematics,
-            Matrix<N3, N1> stateStdDevs, Matrix<N3, N1> measurementStdDevs, double nominalDtSeconds) {
-        m_nominalDt = nominalDtSeconds;
+  /**
+   * Constructs a SwerveDrivePose estimator.
+   *
+   * @param gyroAngle          The current gyro angle.
+   * @param initialPoseMeters  The starting pose estimate.
+   * @param stateStdDevs       Standard deviations of model states. Increase these numbers to trust
+   *                           your encoders less.
+   * @param measurementStdDevs Standard deviations of the measurements. Increase these numbers to
+   *                           trust vision less.
+   */
+  public SwerveDrivePoseEstimator(
+          Rotation2d gyroAngle, Pose2d initialPoseMeters, SwerveDriveKinematics kinematics,
+          Matrix<N3, N1> stateStdDevs, Matrix<N3, N1> measurementStdDevs
+  ) {
+    this(gyroAngle, initialPoseMeters, kinematics, stateStdDevs, measurementStdDevs, 0.01);
+  }
 
-        m_observerSystem = new LinearSystem<>(
+  /**
+   * Constructs a SwerveDrivePose estimator.
+   *
+   * @param gyroAngle          The current gyro angle.
+   * @param initialPoseMeters  The starting pose estimate.
+   * @param stateStdDevs       Standard deviations of model states. Increase these numbers to trust
+   *                           your encoders less.
+   * @param measurementStdDevs Standard deviations of the measurements. Increase these numbers to
+   *                           trust vision less.
+   * @param nominalDtSeconds   The time in seconds between each robot loop.
+   */
+  public SwerveDrivePoseEstimator(
+          Rotation2d gyroAngle, Pose2d initialPoseMeters, SwerveDriveKinematics kinematics,
+          Matrix<N3, N1> stateStdDevs, Matrix<N3, N1> measurementStdDevs, double nominalDtSeconds
+  ) {
+    m_nominalDt = nominalDtSeconds;
+
+    var observerSystem = new LinearSystem<>(
             Nat.N3(), Nat.N3(), Nat.N3(),
-            new MatBuilder<>(Nat.N3(), Nat.N3()).fill(
-
+            MatrixUtils.zeros(Nat.N3(), Nat.N3()), // A
+            new MatBuilder<>(Nat.N3(), Nat.N3()).fill( // B
+                    1, 0, 0,
+                    0, 1, 0,
+                    0, 0, 1
             ),
-            new MatBuilder<>(Nat.N3(), Nat.N3()).fill(
-
+            new MatBuilder<>(Nat.N3(), Nat.N3()).fill( // C
+                    1, 0, 0,
+                    0, 1, 0,
+                    0, 0, 1
             ),
-            new MatBuilder<>(Nat.N3(), Nat.N3()).fill(
-
+            MatrixUtils.zeros(Nat.N3(), Nat.N3()), // D
+            new MatBuilder<>(Nat.N3(), Nat.N1()).fill( // uMin
+                    Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY
             ),
-            MatrixUtils.zeros(Nat.N3(), Nat.N3()),
-            new MatBuilder<>(Nat.N3(), Nat.N1()).fill(),
-            new MatBuilder<>(Nat.N3(), Nat.N1()).fill()
-        );
-        m_observer = new KalmanFilter<>(Nat.N3(), Nat.N3(), Nat.N3(), m_observerSystem, stateStdDevs,
+            new MatBuilder<>(Nat.N3(), Nat.N1()).fill( // uMax
+                    Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY
+            )
+    );
+    m_observer = new KalmanFilter<>(Nat.N3(), Nat.N3(), Nat.N3(), observerSystem, stateStdDevs,
             measurementStdDevs, nominalDtSeconds);
-        m_latencyCompensator = new KalmanFilterLatencyCompensator<>();
+    m_kinematics = kinematics;
+    m_latencyCompensator = new KalmanFilterLatencyCompensator<>();
 
-        m_gyroOffset = initialPoseMeters.getRotation().minus(gyroAngle);
-        m_previousAngle = initialPoseMeters.getRotation();
-        m_observer.setXhat(poseToVector(initialPoseMeters));
-    }
+    m_gyroOffset = initialPoseMeters.getRotation().minus(gyroAngle);
+    m_previousAngle = initialPoseMeters.getRotation();
+    m_observer.setXhat(poseToVector(initialPoseMeters));
+  }
 
-    public void addVisionMeasurement(Pose2d visionRobotPose, double timestampSeconds) {
-        m_latencyCompensator.applyPastMeasurement(m_observer, m_nominalDt, poseToVector(visionRobotPose),
-                timestampSeconds);
-    }
+  /**
+   * Add a vision measurement to the Extended Kalman Filter. This will correct the
+   * odometry pose estimate while still accounting for measurement noise.
+   *
+   * <p>This method can be called as infrequently as you want, as long as you are
+   * calling {@link DifferentialDrivePoseEstimator#update} every loop.
+   *
+   * @param visionRobotPose  The pose of the robot as measured by the vision
+   *                         camera.
+   * @param timestampSeconds The timestamp of the vision measurement in seconds
+   *                         since FPGA startup (i.e. the epoch of this timestamp
+   *                         is the same epoch as
+   *                         {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp
+   *                         Timer.getFPGATimestamp}.) This means that you should
+   *                         use Timer.getFPGATimestamp as your time source in
+   *                         this case.
+   */
+  public void addVisionMeasurement(Pose2d visionRobotPose, double timestampSeconds) {
+    m_latencyCompensator.applyPastMeasurement(
+            m_observer, m_nominalDt,
+            poseToVector(visionRobotPose), timestampSeconds
+    );
+  }
 
-    public Pose2d update(Rotation2d gyroAngle, SwerveModuleState... moduleStates) {
-        var angle = gyroAngle.plus(m_gyroOffset);
-        var u = new MatBuilder<>(Nat.N3(), Nat.N1()).fill(leftDistanceMeters, rightDistanceMeters,
-                angle.minus(m_previousAngle).getRadians());
-        m_previousAngle = angle;
+  /**
+   * Updates the the Kalman Filter using only wheel encoder information.
+   * Note that this should be called every loop (and the correct loop period must
+   * be passed into the constructor of this class.)
+   *
+   * @param gyroAngle           The current gyro angle.
+   * @param wheelStates         Velocities and rotations of the swerve modules.
+   * @return The estimated pose of the robot.
+   */
+  @SuppressWarnings("LocalVariableName")
+  public Pose2d update(Rotation2d gyroAngle, SwerveModuleState... wheelStates) {
+    var angle = gyroAngle.plus(m_gyroOffset);
+    var omega = angle.minus(m_previousAngle).getRadians() / m_nominalDt;
 
-        m_latencyCompensator.addObserverState(m_observer, u);
-        m_observer.predict(u, m_nominalDt);
+    var chassisSpeeds = m_kinematics.toChassisSpeeds(wheelStates);
+    var fieldRelativeVelocities = new Pose2d(0, 0, angle).exp(
+            new Twist2d(chassisSpeeds.vxMetersPerSecond,
+                    chassisSpeeds.vyMetersPerSecond,
+                    omega));
 
-        return new Pose2d(m_observer.getXhat(0), m_observer.getXhat(1), new Rotation2d(m_observer.getXhat(2)));
-    }
+    var u = new MatBuilder<>(Nat.N3(), Nat.N1()).fill(
+            fieldRelativeVelocities.getTranslation().getX(),
+            fieldRelativeVelocities.getTranslation().getY(),
+            omega
+    );
+    m_previousAngle = angle;
 
-    // TODO: Deduplicate
-    private Matrix<N3, N1> poseToVector(Pose2d pose) {
-        return new MatBuilder<>(Nat.N3(), Nat.N1()).fill(pose.getTranslation().getX(), pose.getTranslation().getY(),
-                pose.getRotation().getRadians());
-    }
+    m_latencyCompensator.addObserverState(m_observer, u);
+    m_observer.predict(u, m_nominalDt);
+
+    return new Pose2d(
+            m_observer.getXhat(0),
+            m_observer.getXhat(1),
+            new Rotation2d(m_observer.getXhat(2))
+    );
+  }
+
+  // TODO: Deduplicate
+  private Matrix<N3, N1> poseToVector(Pose2d pose) {
+    return new MatBuilder<>(Nat.N3(), Nat.N1()).fill(
+            pose.getTranslation().getX(),
+            pose.getTranslation().getY(),
+            pose.getRotation().getRadians()
+    );
+  }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/UnscentedKalmanFilter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/UnscentedKalmanFilter.java
@@ -10,7 +10,7 @@ import java.util.function.BiFunction;
 
 
 public class UnscentedKalmanFilter<S extends Num, I extends Num,
-        O extends Num> {
+        O extends Num> implements KalmanTypeFilter<S, I, O> {
 
   private final BiFunction<Matrix<S, N1>, Matrix<I, N1>, Matrix<S, N1>> m_f;
   private final BiFunction<Matrix<S, N1>, Matrix<I, N1>, Matrix<O, N1>> m_h;
@@ -78,10 +78,85 @@ public class UnscentedKalmanFilter<S extends Num, I extends Num,
 
     return null;
   }
+  /**
+   * Returns the error covariance matrix P.
+   *
+   * @return the error covariance matrix P.
+   */
+  @Override
+  public Matrix<S, S> getP() {
+    return m_P;
+  }
+
+  /**
+   * Sets the entire error covariance matrix P.
+   *
+   * @param newP The new value of P to use.
+   */
+  @Override
+  public void setP(Matrix<S, S> newP) {
+    m_P = newP;
+  }
+
+  /**
+   * Returns an element of the error covariance matrix P.
+   *
+   * @param row Row of P.
+   * @param col Column of P.
+   * @return the value of the error covariance matrix P at (i, j).
+   */
+  @Override
+  public double getP(int row, int col) {
+    return m_P.get(row, col);
+  }
+
+  /**
+   * Returns the state estimate x-hat.
+   *
+   * @return the state estimate x-hat.
+   */
+  @Override
+  public Matrix<S, N1> getXhat() {
+    return m_xHat;
+  }
+
+  /**
+   * Set initial state estimate x-hat.
+   *
+   * @param xHat The state estimate x-hat.
+   */
+  @SuppressWarnings("ParameterName")
+  @Override
+  public void setXhat(Matrix<S, N1> xHat) {
+    m_xHat = xHat;
+  }
+
+  /**
+   * Returns an element of the state estimate x-hat.
+   *
+   * @param row Row of x-hat.
+   * @return the value of the state estimate x-hat at i.
+   */
+  @Override
+  public double getXhat(int row) {
+    return m_xHat.get(row, 0);
+  }
+
+  /**
+   * Set an element of the initial state estimate x-hat.
+   *
+   * @param row   Row of x-hat.
+   * @param value Value for element of x-hat.
+   */
+  @Override
+  public void setXhat(int row, double value) {
+    m_xHat.set(row, 0, value);
+  }
 
   /**
    * Resets the observer.
    */
+  @Override
   public void reset() {
     m_xHat = new Matrix<>(new SimpleMatrix(states.getNum(), 1));
     m_P = new Matrix<>(new SimpleMatrix(states.getNum(), states.getNum()));
@@ -112,6 +187,17 @@ public class UnscentedKalmanFilter<S extends Num, I extends Num,
 
     }
 
+  }
+
+  /**
+   * Correct the state estimate x-hat using the measurements in y.
+   *
+   * @param u Same control input used in the predict step.
+   * @param y Measurement vector.
+   */
+  @Override
+  public void correct(Matrix<I, N1> u, Matrix<O, N1> y) {
+    correct(u, y, m_h, m_R);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/UnscentedKalmanFilter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/UnscentedKalmanFilter.java
@@ -1,14 +1,19 @@
 package edu.wpi.first.wpilibj.estimator;
 
-import edu.wpi.first.wpilibj.math.StateSpaceUtils;
-import edu.wpi.first.wpiutil.math.*;
-import edu.wpi.first.wpiutil.math.numbers.N1;
+import java.util.function.BiFunction;
+
 import org.ejml.dense.row.CommonOps_DDRM;
 import org.ejml.simple.SimpleMatrix;
 
-import java.util.function.BiFunction;
+import edu.wpi.first.wpilibj.math.StateSpaceUtils;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.Num;
+import edu.wpi.first.wpiutil.math.SimpleMatrixUtils;
+import edu.wpi.first.wpiutil.math.numbers.N1;
 
 
+@SuppressWarnings("MemberName")
 public class UnscentedKalmanFilter<S extends Num, I extends Num,
         O extends Num> implements KalmanTypeFilter<S, I, O> {
 
@@ -23,25 +28,37 @@ public class UnscentedKalmanFilter<S extends Num, I extends Num,
   /**
    * The inputs of the system.
    */
-  private final Nat<I> inputs;
+  private final Nat<I> m_inputs;
   /**
    * The outputs of the system.
    */
-  private final Nat<O> outputs;
+  private final Nat<O> m_outputs;
   private Matrix<S, N1> m_xHat;
   private Matrix<S, S> m_P;
   private Matrix m_sigmasF;
-  // TODO where is this initilized?
+  // TODO where is this initialized?
   private MerweScaledSigmaPoints<S> m_pts;
 
+  /**
+   * Constructs an Unscented Kalman Filter.
+   *
+   * @param states TODO
+   * @param inputs TODO
+   * @param outputs TODO
+   * @param f TODO
+   * @param h TODO
+   * @param stateStdDevs TODO
+   * @param measurementStdDevs TODO
+   */
+  @SuppressWarnings("ParameterName")
   public UnscentedKalmanFilter(Nat<S> states, Nat<I> inputs, Nat<O> outputs,
                                BiFunction<Matrix<S, N1>, Matrix<I, N1>, Matrix<S, N1>> f,
                                BiFunction<Matrix<S, N1>, Matrix<I, N1>, Matrix<O, N1>> h,
                                Matrix<S, N1> stateStdDevs,
                                Matrix<O, N1> measurementStdDevs) {
     this.states = states;
-    this.inputs = inputs;
-    this.outputs = outputs;
+    this.m_inputs = inputs;
+    this.m_outputs = outputs;
 
     m_f = f;
     m_h = h;
@@ -52,9 +69,9 @@ public class UnscentedKalmanFilter<S extends Num, I extends Num,
   }
 
   @SuppressWarnings("ParameterName")
-  public static <S extends Num, CovDim extends Num>
-  SimpleMatrixUtils.Pair<Matrix<N1, CovDim>, Matrix<CovDim, CovDim>> unscentedTransform(
-          S s, CovDim dim, Matrix sigmas, Matrix Wm, Matrix Wc, Matrix noiseCov
+  private static <S extends Num, C extends Num>
+  SimpleMatrixUtils.Pair<Matrix<N1, C>, Matrix<C, C>> unscentedTransform(
+          S s, C dim, Matrix sigmas, Matrix Wm, Matrix Wc, Matrix noiseCov
   ) {
     if (sigmas.getNumCols() != 2 * s.getNum() + 1 || sigmas.getNumCols() != dim.getNum()) {
       throw new IllegalArgumentException("Sigmas must be 2 * states + 1 by covDim! Got "
@@ -78,6 +95,7 @@ public class UnscentedKalmanFilter<S extends Num, I extends Num,
 
     return null;
   }
+
   /**
    * Returns the error covariance matrix P.
    *
@@ -86,16 +104,6 @@ public class UnscentedKalmanFilter<S extends Num, I extends Num,
   @Override
   public Matrix<S, S> getP() {
     return m_P;
-  }
-
-  /**
-   * Sets the entire error covariance matrix P.
-   *
-   * @param newP The new value of P to use.
-   */
-  @Override
-  public void setP(Matrix<S, S> newP) {
-    m_P = newP;
   }
 
   /**
@@ -111,6 +119,16 @@ public class UnscentedKalmanFilter<S extends Num, I extends Num,
   }
 
   /**
+   * Sets the entire error covariance matrix P.
+   *
+   * @param newP The new value of P to use.
+   */
+  @Override
+  public void setP(Matrix<S, S> newP) {
+    m_P = newP;
+  }
+
+  /**
    * Returns the state estimate x-hat.
    *
    * @return the state estimate x-hat.
@@ -118,17 +136,6 @@ public class UnscentedKalmanFilter<S extends Num, I extends Num,
   @Override
   public Matrix<S, N1> getXhat() {
     return m_xHat;
-  }
-
-  /**
-   * Set initial state estimate x-hat.
-   *
-   * @param xHat The state estimate x-hat.
-   */
-  @SuppressWarnings("ParameterName")
-  @Override
-  public void setXhat(Matrix<S, N1> xHat) {
-    m_xHat = xHat;
   }
 
   /**
@@ -140,6 +147,18 @@ public class UnscentedKalmanFilter<S extends Num, I extends Num,
   @Override
   public double getXhat(int row) {
     return m_xHat.get(row, 0);
+  }
+
+
+  /**
+   * Set initial state estimate x-hat.
+   *
+   * @param xHat The state estimate x-hat.
+   */
+  @SuppressWarnings("ParameterName")
+  @Override
+  public void setXhat(Matrix<S, N1> xHat) {
+    m_xHat = xHat;
   }
 
   /**
@@ -178,12 +197,12 @@ public class UnscentedKalmanFilter<S extends Num, I extends Num,
       var x = new Matrix<S, N1>(temp.transpose());
 
       // set the block from i, 0 to i+1, States to the result of RungeKutta
-//            var rungeKutta = RungeKuttaHelper.RungeKutta(m_f, x, u, dtSeconds).transpose();
+      //var rungeKutta = RungeKuttaHelper.RungeKutta(m_f, x, u, dtSeconds).transpose();
 
-//            Eigen::Matrix<double, States, 1> x =
-//                    sigmas.template block<1, States>(i, 0).transpose();
-//            m_sigmasF.template block<1, States>(i, 0) =
-//            RungeKutta(m_f, x, u, dt).transpose();
+      //Eigen::Matrix<double, States, 1> x =
+      //        sigmas.template block<1, States>(i, 0).transpose();
+      //m_sigmasF.template block<1, States>(i, 0) =
+      //RungeKutta(m_f, x, u, dt).transpose();
 
     }
 
@@ -195,6 +214,7 @@ public class UnscentedKalmanFilter<S extends Num, I extends Num,
    * @param u Same control input used in the predict step.
    * @param y Measurement vector.
    */
+  @SuppressWarnings("ParameterName")
   @Override
   public void correct(Matrix<I, N1> u, Matrix<O, N1> y) {
     correct(u, y, m_h, m_R);
@@ -202,8 +222,8 @@ public class UnscentedKalmanFilter<S extends Num, I extends Num,
 
   /**
    * Correct the state estimate x-hat using the measurements in y.
-   * <p>
-   * This is useful for when the measurements available during a timestep's
+   *
+   * <p>This is useful for when the measurements available during a timestep's
    * Correct() call vary. The h(x, u) passed to the constructor is used if one
    * is not provided (the two-argument version of this function).
    *
@@ -213,6 +233,7 @@ public class UnscentedKalmanFilter<S extends Num, I extends Num,
    *          the measurement vector.
    * @param R Measurement noise covariance matrix.
    */
+  @SuppressWarnings("ParameterName")
   public void correct(
           Matrix<I, N1> u,
           Matrix<O, N1> y,

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/DifferentialDrivePoseEstimatorTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/DifferentialDrivePoseEstimatorTest.java
@@ -1,0 +1,111 @@
+package edu.wpi.first.wpilibj.estimator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.geometry.Transform2d;
+import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryGenerator;
+import edu.wpi.first.wpiutil.math.MatBuilder;
+import edu.wpi.first.wpiutil.math.Nat;
+
+import org.junit.jupiter.api.Test;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XYChartBuilder;
+
+public class DifferentialDrivePoseEstimatorTest {
+    @Test
+    public void testAccuracy() {
+        var estimator = new DifferentialDrivePoseEstimator(new Rotation2d(), new Pose2d(),
+                new MatBuilder<>(Nat.N3(), Nat.N1()).fill(0.02, 0.02, 0.01),
+                new MatBuilder<>(Nat.N3(), Nat.N1()).fill(0.1, 0.1, 0.01));
+
+        var traj = TrajectoryGenerator.generateTrajectory(
+                List.of(new Pose2d(), new Pose2d(20, 20, Rotation2d.fromDegrees(0)),
+                        new Pose2d(23, 23, Rotation2d.fromDegrees(173)), new Pose2d(54, 54, new Rotation2d())),
+                new TrajectoryConfig(0.5, 2));
+
+        var kinematics = new DifferentialDriveKinematics(1);
+        var rand = new Random();
+
+        List<Double> trajXs = new ArrayList<>();
+        List<Double> trajYs = new ArrayList<>();
+        List<Double> observerXs = new ArrayList<>();
+        List<Double> observerYs = new ArrayList<>();
+        List<Double> visionXs = new ArrayList<>();
+        List<Double> visionYs = new ArrayList<>();
+
+        final double dt = 0.01;
+        double t = 0.0;
+
+        final double visionUpdateRate = 0.1;
+        Pose2d lastVisionPose = null;
+        double lastVisionUpdateRealTimestamp = Double.NEGATIVE_INFINITY;
+        double lastVisionUpdateTime = Double.NEGATIVE_INFINITY;
+
+        double maxError = Double.NEGATIVE_INFINITY;
+        double errorSum = 0;
+        while (t <= traj.getTotalTimeSeconds()) {
+            var groundtruthState = traj.sample(t);
+            var input = kinematics.toWheelSpeeds(new ChassisSpeeds(groundtruthState.velocityMetersPerSecond, 0.0,
+                    // ds/dt * dtheta/ds = dtheta/dt
+                    groundtruthState.velocityMetersPerSecond * groundtruthState.curvatureRadPerMeter));
+
+            if (lastVisionUpdateTime + visionUpdateRate < t) {
+                if (lastVisionPose != null) {
+                    estimator.addVisionMeasurement(lastVisionPose, lastVisionUpdateRealTimestamp);
+                }
+                lastVisionPose = groundtruthState.poseMeters.transformBy(
+                        new Transform2d(new Translation2d(rand.nextGaussian() * 0.1, rand.nextGaussian() * 0.1),
+                                new Rotation2d(rand.nextGaussian() * 0.01)));
+                lastVisionUpdateRealTimestamp = Timer.getFPGATimestamp();
+                lastVisionUpdateTime = t;
+
+                visionXs.add(lastVisionPose.getTranslation().getX());
+                visionYs.add(lastVisionPose.getTranslation().getY());
+            }
+
+            var xHat = estimator.update(
+                    groundtruthState.poseMeters.getRotation().plus(new Rotation2d(rand.nextGaussian() * 0.01)),
+                    input.leftMetersPerSecond * dt + rand.nextGaussian() * 0.02,
+                    input.rightMetersPerSecond * dt + rand.nextGaussian() * 0.02);
+
+            double error = groundtruthState.poseMeters.getTranslation().getDistance(xHat.getTranslation());
+            if (error > maxError) {
+                maxError = error;
+            }
+            errorSum += error;
+
+            trajXs.add(groundtruthState.poseMeters.getTranslation().getX());
+            trajYs.add(groundtruthState.poseMeters.getTranslation().getY());
+            observerXs.add(xHat.getTranslation().getX());
+            observerYs.add(xHat.getTranslation().getY());
+
+            t += dt;
+        }
+
+        System.out.println("Mean error (meters): " + errorSum / (traj.getTotalTimeSeconds() / dt));
+        System.out.println("Max error (meters):  " + maxError);
+
+//        var chartBuilder = new XYChartBuilder();
+//        chartBuilder.title = "The Magic of Sensor Fusion";
+//        var chart = chartBuilder.build();
+//
+//        chart.addSeries("Vision", visionXs, visionYs);
+//        chart.addSeries("Trajectory", trajXs, trajYs);
+//        chart.addSeries("xHat", observerXs, observerYs);
+//
+//        new SwingWrapper<>(chart).displayChart();
+//        try {
+//         Thread.sleep(1000000000);
+//        } catch (InterruptedException e) {
+//        }
+    }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/SwerveDrivePoseEstimatorTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/SwerveDrivePoseEstimatorTest.java
@@ -6,7 +6,6 @@ import edu.wpi.first.wpilibj.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.geometry.Transform2d;
 import edu.wpi.first.wpilibj.geometry.Translation2d;
 import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
-import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
 import edu.wpi.first.wpilibj.kinematics.SwerveDriveKinematics;
 import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig;
 import edu.wpi.first.wpilibj.trajectory.TrajectoryGenerator;
@@ -84,7 +83,7 @@ public class SwerveDrivePoseEstimatorTest {
                 moduleState.speedMetersPerSecond += rand.nextGaussian() * 1;
             }
 
-            var xHat = estimator.update(
+            var xHat = estimator.updateWithTime(
                     groundtruthState.poseMeters.getRotation().plus(new Rotation2d(rand.nextGaussian() * 0.001)),
                     moduleStates);
 

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/SwerveDrivePoseEstimatorTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/SwerveDrivePoseEstimatorTest.java
@@ -1,0 +1,122 @@
+package edu.wpi.first.wpilibj.estimator;
+
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.geometry.Transform2d;
+import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
+import edu.wpi.first.wpilibj.kinematics.SwerveDriveKinematics;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryGenerator;
+import edu.wpi.first.wpiutil.math.MatBuilder;
+import edu.wpi.first.wpiutil.math.Nat;
+import org.junit.jupiter.api.Test;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XYChartBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+public class SwerveDrivePoseEstimatorTest {
+    @Test
+    public void testAccuracy() {
+        var kinematics = new SwerveDriveKinematics(
+                new Translation2d(1, 1),
+                new Translation2d(1, -1),
+                new Translation2d(-1, -1),
+                new Translation2d(-1, 1)
+        );
+        var estimator = new SwerveDrivePoseEstimator(new Rotation2d(), new Pose2d(), kinematics,
+                new MatBuilder<>(Nat.N3(), Nat.N1()).fill(3, 3, 3),
+                new MatBuilder<>(Nat.N3(), Nat.N1()).fill(0.1, 0.1, 0.1));
+
+        var traj = TrajectoryGenerator.generateTrajectory(
+                List.of(new Pose2d(), new Pose2d(20, 20, Rotation2d.fromDegrees(0)),
+                        new Pose2d(23, 23, Rotation2d.fromDegrees(173)), new Pose2d(54, 54, new Rotation2d())),
+                new TrajectoryConfig(0.5, 2));
+
+        var rand = new Random(4915l);
+
+        List<Double> trajXs = new ArrayList<>();
+        List<Double> trajYs = new ArrayList<>();
+        List<Double> observerXs = new ArrayList<>();
+        List<Double> observerYs = new ArrayList<>();
+        List<Double> visionXs = new ArrayList<>();
+        List<Double> visionYs = new ArrayList<>();
+
+        final double dt = 0.01;
+        double t = 0.0;
+
+        final double visionUpdateRate = 0.1;
+        Pose2d lastVisionPose = null;
+        double lastVisionUpdateRealTimestamp = Double.NEGATIVE_INFINITY;
+        double lastVisionUpdateTime = Double.NEGATIVE_INFINITY;
+
+        double maxError = Double.NEGATIVE_INFINITY;
+        double errorSum = 0;
+        while (t <= traj.getTotalTimeSeconds()) {
+            var groundtruthState = traj.sample(t);
+
+            if (lastVisionUpdateTime + visionUpdateRate < t) {
+                if (lastVisionPose != null) {
+                    estimator.addVisionMeasurement(lastVisionPose, lastVisionUpdateRealTimestamp);
+                }
+                lastVisionPose = groundtruthState.poseMeters.transformBy(
+                        new Transform2d(new Translation2d(rand.nextGaussian() * 0.1, rand.nextGaussian() * 0.1),
+                                new Rotation2d(rand.nextGaussian() * 0.01)));
+                lastVisionUpdateRealTimestamp = Timer.getFPGATimestamp();
+                lastVisionUpdateTime = t;
+
+                visionXs.add(lastVisionPose.getTranslation().getX());
+                visionYs.add(lastVisionPose.getTranslation().getY());
+            }
+
+            var moduleStates = kinematics.toSwerveModuleStates(new ChassisSpeeds(
+                    groundtruthState.velocityMetersPerSecond,
+                    0.0,
+                    groundtruthState.velocityMetersPerSecond * groundtruthState.curvatureRadPerMeter)
+            );
+            for (var moduleState : moduleStates) {
+                moduleState.angle = moduleState.angle.plus(new Rotation2d(rand.nextGaussian() * 0.5));
+                moduleState.speedMetersPerSecond += rand.nextGaussian() * 1;
+            }
+
+            var xHat = estimator.update(
+                    groundtruthState.poseMeters.getRotation().plus(new Rotation2d(rand.nextGaussian() * 0.001)),
+                    moduleStates);
+
+            double error = groundtruthState.poseMeters.getTranslation().getDistance(xHat.getTranslation());
+            if (error > maxError) {
+                maxError = error;
+            }
+            errorSum += error;
+
+            trajXs.add(groundtruthState.poseMeters.getTranslation().getX());
+            trajYs.add(groundtruthState.poseMeters.getTranslation().getY());
+            observerXs.add(xHat.getTranslation().getX());
+            observerYs.add(xHat.getTranslation().getY());
+
+            t += dt;
+        }
+
+        System.out.println("Mean error (meters): " + errorSum / (traj.getTotalTimeSeconds() / dt));
+        System.out.println("Max error (meters):  " + maxError);
+
+//        var chartBuilder = new XYChartBuilder();
+//        chartBuilder.title = "The Magic of Sensor Fusion";
+//        var chart = chartBuilder.build();
+//
+//        chart.addSeries("Vision", visionXs, visionYs);
+//        chart.addSeries("Trajectory", trajXs, trajYs);
+//        chart.addSeries("xHat", observerXs, observerYs);
+//
+//        new SwingWrapper<>(chart).displayChart();
+//        try {
+//            Thread.sleep(1000000000);
+//        } catch (InterruptedException e) {
+//        }
+    }
+}


### PR DESCRIPTION
This adds easy-to-use latency compensated (Extended) Kalman Filter wrappers that fuse encoder and vision information. This is a major part of making the new sensor fusion stuff usable by the average team.