### PR TITLE
Improve accuracy of pose estimators by adding more measurements

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/ExtendedKalmanFilter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/ExtendedKalmanFilter.java
@@ -19,6 +19,15 @@ import edu.wpi.first.wpiutil.math.Nat;
 import edu.wpi.first.wpiutil.math.Num;
 import edu.wpi.first.wpiutil.math.numbers.N1;
 
+/**
+ * Kalman filters combine predictions from a model and measurements to give an estimate of the true
+ * system state. This is useful because many states cannot be measured directly as a result of
+ * sensor noise, or because the state is "hidden".
+ *
+ * <p>The Extended Kalman filter is just like the {@link KalmanFilter Kalman filter}, but we make a
+ * linear approximation of nonlinear dynamics and/or nonlinear measurement models. This means that
+ * the EKF works with nonlinear systems.
+ */
 public class ExtendedKalmanFilter<S extends Num, I extends Num, O extends Num>
         implements KalmanTypeFilter<S, I, O> {
   private final Nat<S> m_states;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/ExtendedKalmanFilter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/ExtendedKalmanFilter.java
@@ -265,7 +265,7 @@ public class ExtendedKalmanFilter<S extends Num, I extends Num, O extends Num>
     // K^T = S^T.solve(CP^T)
     // K = (S^T.solve(CP^T))^T
     //
-    // Now we have the optimal Kalman gain
+    // Now we have the Kalman gain
     final var K = new Matrix<S, R>(S.getStorage().transpose()
             .solve(C.times(m_P.transpose()).getStorage()).transpose());
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanFilter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanFilter.java
@@ -30,7 +30,7 @@ import edu.wpi.first.wpiutil.math.numbers.N1;
  * the model.
  *
  * <p>For more on the underlying math, read
- * https://file.tavsys.net/control/controls-engineering-in-frc.pdf section 9.
+ * https://file.tavsys.net/control/controls-engineering-in-frc.pdf chapter 9.
  */
 public class KalmanFilter<S extends Num, I extends Num,
         O extends Num> implements KalmanTypeFilter<S, I, O> {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanFilter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanFilter.java
@@ -19,22 +19,18 @@ import edu.wpi.first.wpiutil.math.Num;
 import edu.wpi.first.wpiutil.math.numbers.N1;
 
 /**
- * Luenberger observers combine predictions from a model and measurements to
- * give an estimate of the true system state.
+ * A Kalman filter combines predictions from a model and measurements to give an estimate of the true
+ * system state. This is useful because many states cannot be measured directly as a result of
+ * sensor noise, or because the state is "hidden".
  *
- * <p>Luenberger observers use an L gain matrix to determine whether to trust the
- * model or measurements more. Kalman filter theory uses statistics to compute
- * an optimal L gain (alternatively called the Kalman gain, K) which minimizes
- * the sum of squares error in the state estimate.
- *
- * <p>Luenberger observers run the prediction and correction steps simultaneously
- * while Kalman filters run them sequentially. To implement a discrete-time
- * Kalman filter as a Luenberger observer, use the following mapping:
- * <pre>C = H, L = A * K</pre>
- * (H is the measurement matrix).
+ * <p>Kalman filters use a K gain matrix to determine whether to trust the model or measurements
+ * more. Kalman filter theory uses statistics to compute an optimal K gain which minimizes the sum
+ * of squares error in the state estimate. This K gain is used to correct the state estimate by
+ * some amount of the difference between the actual measurements and the measurements predicted by
+ * the model.
  *
  * <p>For more on the underlying math, read
- * https://file.tavsys.net/control/controls-engineering-in-frc.pdf.
+ * https://file.tavsys.net/control/controls-engineering-in-frc.pdf section 9.
  */
 public class KalmanFilter<S extends Num, I extends Num,
         O extends Num> implements KalmanTypeFilter<S, I, O> {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanTypeFilter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanTypeFilter.java
@@ -8,8 +8,11 @@
 package edu.wpi.first.wpilibj.estimator;
 
 import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.Nat;
 import edu.wpi.first.wpiutil.math.Num;
 import edu.wpi.first.wpiutil.math.numbers.N1;
+
+import java.util.function.BiFunction;
 
 @SuppressWarnings("ParameterName")
 interface KalmanTypeFilter<S extends Num, I extends Num, O extends Num> {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/UnscentedKalmanFilter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/UnscentedKalmanFilter.java
@@ -14,6 +14,16 @@ import edu.wpi.first.wpiutil.math.Num;
 import edu.wpi.first.wpiutil.math.SimpleMatrixUtils;
 import edu.wpi.first.wpiutil.math.numbers.N1;
 
+/**
+ * A Kalman filter combines predictions from a model and measurements to give an estimate of the
+ * true ystem state. This is useful because many states cannot be measured directly as a result of
+ * sensor noise, or because the state is "hidden".
+ *
+ * <p>The Unscented Kalman filter is similar to the {@link KalmanFilter Kalman filter}, except that
+ * it propagates carefully chosen points called sigma points through the non-linear model to obtain
+ * an estimate of the true covariance (as opposed to a linearized version of it). This means that
+ * the UKF works with nonlinear systems.
+ */
 @SuppressWarnings("MemberName")
 public class UnscentedKalmanFilter<S extends Num, I extends Num,
         O extends Num> implements KalmanTypeFilter<S, I, O> {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/DifferentialDrivePoseEstimatorTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/DifferentialDrivePoseEstimatorTest.java
@@ -79,7 +79,7 @@ public class DifferentialDrivePoseEstimatorTest {
 
       if (lastVisionUpdateTime + visionUpdateRate + rand.nextGaussian() * 0.4 < t) {
         if (lastVisionPose != null) {
-//          estimator.addVisionMeasurement(lastVisionPose, lastVisionUpdateTime);
+          estimator.addVisionMeasurement(lastVisionPose, lastVisionUpdateTime);
         }
         var groundPose = groundtruthState.poseMeters;
         lastVisionPose = new Pose2d(
@@ -106,8 +106,7 @@ public class DifferentialDrivePoseEstimatorTest {
               t,
               groundtruthState.poseMeters.getRotation().plus(rotNoise),
               input,
-              0, 0
-              //distanceLeft, distanceRight
+              distanceLeft, distanceRight
       );
 
       double error =

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/ExtendedKalmanFilterTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/ExtendedKalmanFilterTest.java
@@ -60,7 +60,7 @@ public class ExtendedKalmanFilterTest {
     result.set(1, 0, v * Math.sin(x.get(2, 0)));
     result.set(2, 0, (vr - vl) / (2.0 * rb));
     result.set(3, 0, k1 * ((C1 * vl) + (C2 * Vl)) + k2 * ((C1 * vr) + (C2 * Vr)));
-    result.set(4, 0, k2 * ((C1 * vl) + (C2 * Vl)) + k1 * ((C1 * vr) + (C2 * vr)));
+    result.set(4, 0, k2 * ((C1 * vl) + (C2 * Vl)) + k1 * ((C1 * vr) + (C2 * Vr)));
     return result;
   }
 

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/SwerveDrivePoseEstimatorTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/SwerveDrivePoseEstimatorTest.java
@@ -39,7 +39,8 @@ public class SwerveDrivePoseEstimatorTest {
     );
     var estimator = new SwerveDrivePoseEstimator(
             new Rotation2d(), new Pose2d(), kinematics,
-            VecBuilder.fill(3, 3, 3),
+            VecBuilder.fill(0.1, 0.1, 0.1),
+            VecBuilder.fill(0.05),
             VecBuilder.fill(0.1, 0.1, 0.1)
     );
 
@@ -74,10 +75,14 @@ public class SwerveDrivePoseEstimatorTest {
         if (lastVisionPose != null) {
           estimator.addVisionMeasurement(lastVisionPose, lastVisionUpdateTime);
         }
-        lastVisionPose = groundtruthState.poseMeters.transformBy(
-                new Transform2d(new Translation2d(rand.nextGaussian() * 0.1,
-                        rand.nextGaussian() * 0.1),
-                        new Rotation2d(rand.nextGaussian() * 0.01)));
+        lastVisionPose = new Pose2d(
+                new Translation2d(
+                    groundtruthState.poseMeters.getTranslation().getX() + rand.nextGaussian() * 0.1,
+                    groundtruthState.poseMeters.getTranslation().getY() + rand.nextGaussian() * 0.1
+                ),
+                new Rotation2d(
+                    rand.nextGaussian() * 0.01).plus(groundtruthState.poseMeters.getRotation())
+        );
         lastVisionUpdateTime = t;
 
         visionXs.add(lastVisionPose.getTranslation().getX());
@@ -97,7 +102,7 @@ public class SwerveDrivePoseEstimatorTest {
       var xHat = estimator.updateWithTime(
               t,
               groundtruthState.poseMeters.getRotation()
-                      .plus(new Rotation2d(rand.nextGaussian() * 0.001)),
+                      .plus(new Rotation2d(rand.nextGaussian() * 0.05)),
               moduleStates);
 
       double error =
@@ -116,11 +121,11 @@ public class SwerveDrivePoseEstimatorTest {
     }
 
     assertEquals(
-            0.0, errorSum / (traj.getTotalTimeSeconds() / dt), 0.2,
+            0.0, errorSum / (traj.getTotalTimeSeconds() / dt), 0.15,
             "Incorrect mean error"
     );
     assertEquals(
-            0.0, maxError, 0.2,
+            0.0, maxError, 0.34,
             "Incorrect max error"
     );
 


### PR DESCRIPTION
This makes it so that the pose estimators always call correct with angle measurements, and then also call correct with vision measurements as they come in. This also fixes an issue in the Kalman filter where the wrong D would be used if you used the overload of correct that takes a y of an arbitary size. I also threw in a fix so that we rediscretize R in predict.

- [x] Add the appropriate correct calls and changes to the latency compensator.
- [x] Change the pose estimators to pass additional measurements where appropriate.
- [x] Get ~~roasted~~ reviewed by someone who actually knows what he's doing. I'm pretty sure the way the diff drive pose estimator is dealing with encoder distances is wrong... This needs to be discussed before this gets merged. 